### PR TITLE
Throw an error if speed is unsupported on iOS + better documentation

### DIFF
--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -359,10 +359,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     _player.rate = speed;
     result(nil);
   } else if (speed < 0 || speed > 2.0) {
-    result([FlutterError
-        errorWithCode:@"unsupported_speed"
-              message:@"Speed must be >= 0.0 and <= 2.0"
-              details:nil]);
+    result([FlutterError errorWithCode:@"unsupported_speed"
+                               message:@"Speed must be >= 0.0 and <= 2.0"
+                               details:nil]);
   } else if ((speed > 1.0 && _player.currentItem.canPlayFastForward) ||
              (speed < 1.0 && _player.currentItem.canPlaySlowForward)) {
     _player.rate = speed;

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -361,7 +361,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   } else if (speed < 0 || speed > 2.0) {
     result([FlutterError
         errorWithCode:@"unsupported_speed"
-              message:@"Speed must be greater than or equal to 0.0 and less than 2.0"
+              message:@"Speed must be >= 0.0 and <= 2.0"
               details:nil]);
   } else if ((speed > 1.0 && _player.currentItem.canPlayFastForward) ||
              (speed < 1.0 && _player.currentItem.canPlaySlowForward)) {

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -354,16 +354,29 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   _player.volume = (float)((volume < 0.0) ? 0.0 : ((volume > 1.0) ? 1.0 : volume));
 }
 
-- (void)setSpeed:(double)speed {
+- (void)setSpeed:(double)speed result:(FlutterResult)result {
   if (speed == 1.0 || speed == 0.0) {
     _player.rate = speed;
+    result(nil);
   } else if (speed < 0 || speed > 2.0) {
-    NSLog(@"Speed outside supported range %f", speed);
+    result([FlutterError
+        errorWithCode:@"unsupported_speed"
+              message:@"Speed must be greater than or equal to 0.0 and less than 2.0"
+              details:nil]);
   } else if ((speed > 1.0 && _player.currentItem.canPlayFastForward) ||
              (speed < 1.0 && _player.currentItem.canPlaySlowForward)) {
     _player.rate = speed;
+    result(nil);
   } else {
-    NSLog(@"Unsupported speed. Cannot play fast/slow forward: %f", speed);
+    if (speed > 1.0) {
+      result([FlutterError errorWithCode:@"unsupported_fast_forward"
+                                 message:@"This video cannot be played fast forward"
+                                 details:nil]);
+    } else {
+      result([FlutterError errorWithCode:@"unsupported_slow_forward"
+                                 message:@"This video cannot be played slow forward"
+                                 details:nil]);
+    }
   }
 }
 
@@ -520,8 +533,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
       [player pause];
       result(nil);
     } else if ([@"setSpeed" isEqualToString:call.method]) {
-      [player setSpeed:[[argsMap objectForKey:@"speed"] doubleValue]];
-      result(nil);
+      [player setSpeed:[[argsMap objectForKey:@"speed"] doubleValue] result:result];
+      return;
     } else {
       result(FlutterMethodNotImplemented);
     }

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -416,8 +416,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       return;
     }
 
-    // On iOS setting the speed will start playing the video automatically
-    // Do not change the video speed until after the video is played
+    // On iOS setting the speed on an AVPlayer starts playing
+    // the video straightaway. We avoid this surprising behaviour
+    // by not changing the speed of the player until after the video
+    // starts playing
     if (!value.isPlaying) {
       return;
     }
@@ -432,6 +434,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   ///
   /// [speed] can be 0.5x, 1x, 2x
   /// by default speed value is 1.0
+  ///
+  /// Negative speeds are not supported
+  /// speeds above 2x are not supported on iOS
   Future<void> setSpeed(double speed) async {
     value = value.copyWith(speed: speed);
     await _applySpeed();


### PR DESCRIPTION
- Throw a FlutterError if the speed is unsupported in iOS
- Improve documentation for supported speeds in video_player
- Improve comment on why setSpeed is not called when the video is not playing

~~I'll test the changes this evening. I'll ping you once this PR is ready to be merged.~~
Manual tests completed. Setting the speed on videos works exactly as before these PR's changes (unless speed is out of range, an error is thrown)